### PR TITLE
Update lambda-action version to v0.2.0 in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./bin/build.sh
 
       - name: Deploy to AWS Lambda
-        uses: appleboy/lambda-action@v1
+        uses: appleboy/lambda-action@v0.2.0
         with:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous deployment pipeline to pin the AWS Lambda deployment step to a specific action version in GitHub Actions.
  * No changes to application features, user interface, or APIs.
  * End users are unaffected; behavior and functionality remain the same.
  * All other workflow steps remain unchanged, and builds/deployments continue as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->